### PR TITLE
Allow the script to take section names and/or ids

### DIFF
--- a/cli.php
+++ b/cli.php
@@ -47,7 +47,7 @@ plex_log('Welcome to the Plex Exporter v'.$plex_export_version);
       foreach($all_sections as $j=>$section) {
         $key = array_search($section_key_or_title, $section);
         if($key == 'title' || $key == 'key')
-          array_push($sections_to_export, $section);
+          $sections_to_export[$section['key']] = $section;
       }
     }
 


### PR DESCRIPTION
This commit allows you to do things like this:

```
$ cli.php -sections="My Movies,Kids Movies"
```

The old id-based section selection still works.
